### PR TITLE
Add mpirun args from environment with runParallel

### DIFF
--- a/bin/tools/RunFunctions
+++ b/bin/tools/RunFunctions
@@ -139,9 +139,9 @@ runParallel()
     else
         echo "Running $APP_RUN in parallel on $PWD using $nProcs processes"
         if [ "$LOG_APPEND" = "true" ]; then
-            ( mpirun -np $nProcs $APP_RUN -parallel "$@" < /dev/null >> log.$LOG_SUFFIX 2>&1 )
+            ( mpirun $runParallelMpirunArgs -np $nProcs $APP_RUN -parallel "$@" < /dev/null >> log.$LOG_SUFFIX 2>&1 )
         else
-            ( mpirun -np $nProcs $APP_RUN -parallel "$@" < /dev/null > log.$LOG_SUFFIX 2>&1 )
+            ( mpirun $runParallelMpirunArgs -np $nProcs $APP_RUN -parallel "$@" < /dev/null > log.$LOG_SUFFIX 2>&1 )
         fi
     fi
 }


### PR DESCRIPTION
Please can we add a way to pass arguments to mpirun when using runParallel?  I can't see a way to do it other that edit the file myself or rewrite the command using mpirun in the Allrun scripts.